### PR TITLE
Updates the example for traditional MVC applications

### DIFF
--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/HttpSessionConfig.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/HttpSessionConfig.java
@@ -15,19 +15,11 @@
  */
 package org.springframework.session.mongodb.examples.config;
 
-import java.time.Duration;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.session.data.mongo.JdkMongoSessionConverter;
 import org.springframework.session.data.mongo.config.annotation.web.http.EnableMongoHttpSession;
 
 // tag::class[]
-@EnableMongoHttpSession // <1>
+@EnableMongoHttpSession(maxInactiveIntervalInSeconds = 1800) // <1>
 public class HttpSessionConfig {
 
-	@Bean
-	public JdkMongoSessionConverter jdkMongoSessionConverter() {
-		return new JdkMongoSessionConverter(Duration.ofMinutes(30)); // <2>
-	}
 }
 // end::class[]


### PR DESCRIPTION
It is not necessary to declare an JdkMongoSessionConverter bean since it will be used by default. This update is depending on https://github.com/spring-projects/spring-session-data-mongodb/pull/26