### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SessionAttributeForm.java
+++ b/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SessionAttributeForm.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SessionController.java
+++ b/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SessionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SpringSessionMongoReactiveApplication.java
+++ b/spring-session-data-mongodb-reactive-boot/src/main/java/org/springframework/session/mongodb/examples/SpringSessionMongoReactiveApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-reactive-boot/src/test/java/org/springframework/session/mongodb/examples/AttributeTests.java
+++ b/spring-session-data-mongodb-reactive-boot/src/test/java/org/springframework/session/mongodb/examples/AttributeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-reactive-boot/src/test/java/org/springframework/session/mongodb/examples/pages/HomePage.java
+++ b/spring-session-data-mongodb-reactive-boot/src/test/java/org/springframework/session/mongodb/examples/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/EmbeddedMongoPortLogger.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/EmbeddedMongoPortLogger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/SpringSessionMongoTraditionalBoot.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/SpringSessionMongoTraditionalBoot.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/HttpSessionConfig.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/HttpSessionConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/SecurityConfig.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/config/SecurityConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/mvc/IndexController.java
+++ b/spring-session-data-mongodb-traditional-boot/src/main/java/org/springframework/session/mongodb/examples/mvc/IndexController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/BootTests.java
+++ b/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/BootTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/BasePage.java
+++ b/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/BasePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/HomePage.java
+++ b/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/HomePage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/LoginPage.java
+++ b/spring-session-data-mongodb-traditional-boot/src/test/java/org/springframework/session/mongodb/examples/pages/LoginPage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 15 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).